### PR TITLE
Allow mock injection in beans implementing interface by interface reference

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -87,7 +87,7 @@ Simply include the maven dependency (from central maven) to start using @MockInB
 <dependency>
   <groupId>com.teketik</groupId>
   <artifactId>mock-in-bean</artifactId>
-  <version>boot2-v1.3</version>
+  <version>boot2-v1.4</version>
   <scope>test</scope>
 </dependency>
 ```
@@ -100,7 +100,7 @@ Checkout the javadoc for more information.
 
 # Parallel testing
 
-Parallel testing support has been added to Release Candidate version `boot2-v2.0-RC` which allows multiple parallel tests using `MockInBean`/`SpyInBean` to run against their own mock/spy instances without interference.
+Parallel testing support has been added to Release Candidate version `boot2-v2.1-RC` which allows multiple parallel tests using `MockInBean`/`SpyInBean` to run against their own mock/spy instances without interference.
 The dependencies to mock in the beans are now replaced by a proxy that invokes the mock tied to the thread running the test.
 
 *Careful: When running parallel tests, you cannot mock beans that are being used on a different thread than the thread running your test. This is because parallel testing support locates the mocks to use according to the thread and there is no way to find out which mock to use if your test runs on a thread that is not the one where your mock runs.*

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.teketik</groupId>
     <artifactId>mock-in-bean</artifactId>
-    <version>boot2-v2.0-RC</version>
+    <version>boot2-v2.1-RC</version>
     <name>Mock in Bean</name>
     <description>Surgically Inject Mockito Mock/Spy in Spring Beans</description>
     <url>https://github.com/antoinemeyer/mock-in-bean</url>

--- a/src/main/java/com/teketik/test/mockinbean/MockInBeanTestContextManager.java
+++ b/src/main/java/com/teketik/test/mockinbean/MockInBeanTestContextManager.java
@@ -121,10 +121,10 @@ class MockInBeanTestContextManager {
 
                 Object proxy = null;
                 for (InBeanDefinition inBeanDefinition: inBeanDefinitions) {
-                    final Field inBeanDefinitionField = BeanUtils.findField(inBeanDefinition.clazz, definition.getName(), mockOrSpyType);
+                    final Object inBean = BeanUtils.findBean(inBeanDefinition.clazz, inBeanDefinition.name, applicationContext);
+                    final Field inBeanDefinitionField = BeanUtils.findField(inBean.getClass(), definition.getName(), mockOrSpyType);
                     Assert.notNull(inBeanDefinitionField, () -> "Cannot find bean to mock " + mockOrSpyType + " in " + inBeanDefinition.clazz);
                     inBeanDefinitionField.setAccessible(true);
-                    final Object inBean = BeanUtils.findBean(inBeanDefinition.clazz, inBeanDefinition.name, applicationContext);
                     final Object originalFieldValueInBean = ReflectionUtils.getField(
                         inBeanDefinitionField,
                         inBean

--- a/src/test/java/com/teketik/test/mockinbean/test/TestInterface.java
+++ b/src/test/java/com/teketik/test/mockinbean/test/TestInterface.java
@@ -1,0 +1,28 @@
+package com.teketik.test.mockinbean.test;
+
+import com.teketik.test.mockinbean.MockInBean;
+import com.teketik.test.mockinbean.ProxyManagerTestUtils;
+import com.teketik.test.mockinbean.test.components.TestComponent1;
+import com.teketik.test.mockinbean.test.components.TestComponentInterface;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.util.ReflectionTestUtils;
+
+public class TestInterface extends BaseTest {
+
+    @Autowired
+    private TestComponentInterface testComponentInterface;
+
+    @MockInBean(TestComponentInterface.class)
+    private TestComponent1 testComponent1;
+
+    @Test
+    public void test() {
+        Assertions.assertTrue(TestUtils.isMock(testComponent1));
+        Object t1m1 = ReflectionTestUtils.getField(testComponentInterface, "testComponent1");
+        Assertions.assertTrue(ProxyManagerTestUtils.isProxyOf(t1m1, testComponent1));
+    }
+
+}

--- a/src/test/java/com/teketik/test/mockinbean/test/components/TestComponentInterface.java
+++ b/src/test/java/com/teketik/test/mockinbean/test/components/TestComponentInterface.java
@@ -1,0 +1,5 @@
+package com.teketik.test.mockinbean.test.components;
+
+public interface TestComponentInterface {
+
+}

--- a/src/test/java/com/teketik/test/mockinbean/test/components/TestComponentInterfaceImpl.java
+++ b/src/test/java/com/teketik/test/mockinbean/test/components/TestComponentInterfaceImpl.java
@@ -1,0 +1,13 @@
+package com.teketik.test.mockinbean.test.components;
+
+import org.springframework.stereotype.Component;
+
+import javax.annotation.Resource;
+
+@Component
+public class TestComponentInterfaceImpl implements TestComponentInterface {
+
+    @Resource
+    private TestComponent1 testComponent1;
+
+}


### PR DESCRIPTION
Porting https://github.com/antoinemeyer/mock-in-bean/pull/14 changes to RC