### PR TITLE
Allow @MockInBean to be used in meta-annotations

### DIFF
--- a/src/main/java/com/teketik/test/mockinbean/MockInBean.java
+++ b/src/main/java/com/teketik/test/mockinbean/MockInBean.java
@@ -66,7 +66,7 @@ import java.lang.annotation.Target;
  * @author Antoine Meyer
  * @see SpyInBean
  */
-@Target({ElementType.FIELD})
+@Target({ElementType.FIELD, ElementType.ANNOTATION_TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 @Repeatable(MockInBeans.class)
 public @interface MockInBean {

--- a/src/main/java/com/teketik/test/mockinbean/MockInBeans.java
+++ b/src/main/java/com/teketik/test/mockinbean/MockInBeans.java
@@ -16,7 +16,7 @@ import java.lang.annotation.Target;
  *
  * @author Antoine Meyer
  */
-@Target({ElementType.FIELD})
+@Target({ElementType.FIELD, ElementType.ANNOTATION_TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface MockInBeans {
 

--- a/src/test/java/com/teketik/test/mockinbean/test/MockInBeanMetaAnnotationsTest.java
+++ b/src/test/java/com/teketik/test/mockinbean/test/MockInBeanMetaAnnotationsTest.java
@@ -1,0 +1,43 @@
+package com.teketik.test.mockinbean.test;
+
+import com.teketik.test.mockinbean.test.annotations.MockInBeanWithCustomName;
+import com.teketik.test.mockinbean.test.annotations.MockInMultipleComponents;
+import com.teketik.test.mockinbean.test.components.MockableComponent1;
+import com.teketik.test.mockinbean.test.components.MockableComponent2;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class MockInBeanMetaAnnotationsTest extends MockInBeanBaseTest {
+
+    @MockInMultipleComponents
+    private MockableComponent1 mockableComponent1;
+
+    @MockInBeanWithCustomName
+    private MockableComponent2 mockableComponent2;
+
+    /**
+     * Note: Will fail if run individually, run as a class.
+     */
+    @Test
+    void test() {
+        Assertions.assertTrue(TestUtils.isMock(mockableComponent1));
+        Assertions.assertSame(mockableComponent1, ReflectionTestUtils.getField(testComponent1, "mockableComponent1"));
+        Assertions.assertSame(mockableComponent1, ReflectionTestUtils.getField(testComponent2, "mockableComponent1"));
+
+        Assertions.assertTrue(TestUtils.isMock(mockableComponent2));
+        Assertions.assertSame(mockableComponent2, ReflectionTestUtils.getField(testComponent1, "mockableComponent2"));
+        Assertions.assertNotSame(mockableComponent2, ReflectionTestUtils.getField(testComponent2, "mockableComponent2"));
+        Assertions.assertFalse(TestUtils.isMockOrSpy(ReflectionTestUtils.getField(testComponent2, "mockableComponent2")));
+    }
+
+    @Override
+    MockableComponent1 getMockableComponent1() {
+        return mockableComponent1;
+    }
+
+    @Override
+    MockableComponent2 getMockableComponent2() {
+        return mockableComponent2;
+    }
+}

--- a/src/test/java/com/teketik/test/mockinbean/test/annotations/MockInBeanWithCustomName.java
+++ b/src/test/java/com/teketik/test/mockinbean/test/annotations/MockInBeanWithCustomName.java
@@ -1,0 +1,15 @@
+package com.teketik.test.mockinbean.test.annotations;
+
+import com.teketik.test.mockinbean.MockInBean;
+import com.teketik.test.mockinbean.test.components.TestComponent1;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+@MockInBean(TestComponent1.class)
+public @interface MockInBeanWithCustomName {
+}

--- a/src/test/java/com/teketik/test/mockinbean/test/annotations/MockInMultipleComponents.java
+++ b/src/test/java/com/teketik/test/mockinbean/test/annotations/MockInMultipleComponents.java
@@ -1,0 +1,17 @@
+package com.teketik.test.mockinbean.test.annotations;
+
+import com.teketik.test.mockinbean.MockInBean;
+import com.teketik.test.mockinbean.test.components.TestComponent1;
+import com.teketik.test.mockinbean.test.components.TestComponent2;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+@MockInBean(TestComponent1.class)
+@MockInBean(TestComponent2.class)
+public @interface MockInMultipleComponents {
+}


### PR DESCRIPTION
Allow @MockInBean to be used in meta-annotation, so following is possible:

@Target({ElementType.FIELD})
@Retention(RetentionPolicy.RUNTIME)
@MockInBean(A.class)
@MockInBean(B.class)
@MockInBean(C.class)
public @interface MockUserContext {
}