### PR TITLE
v1.8: Fix verify in advised beans

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,6 +1,6 @@
 # Mock in Bean
 
-[@MockInBean](src/main/java/com/teketik/test/mockinbean/MockInBean.java) and [@SpyInBean](src/main/java/com/teketik/test/mockinbean/SpyInBean.java) are alternatives to @MockBean and @SpyBean for Spring Boot tests *(>= 2.2.0 including >= 3.X.X)*.
+[@MockInBean](src/main/java/com/teketik/test/mockinbean/MockInBean.java) and [@SpyInBean](src/main/java/com/teketik/test/mockinbean/SpyInBean.java) are alternatives to @MockBean and @SpyBean for Spring Boot tests *(>= 2.6.15 including >= 3.X.X)*.
 
 They surgically replace a field value in a Spring Bean by a Mock/Spy for the duration of a test and set back the original value afterwards, leaving the Spring Context clean.
 

--- a/README.MD
+++ b/README.MD
@@ -86,7 +86,7 @@ Simply include the maven dependency (from central maven) to start using @MockInB
 <dependency>
   <groupId>com.teketik</groupId>
   <artifactId>mock-in-bean</artifactId>
-  <version>boot2-v1.7</version>
+  <version>boot2-v1.8</version>
   <scope>test</scope>
 </dependency>
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.teketik</groupId>
     <artifactId>mock-in-bean</artifactId>
-    <version>boot2-v1.7</version>
+    <version>boot2-v1.8</version>
     <name>Mock in Bean</name>
     <description>Surgically Inject Mockito Mock/Spy in Spring Beans</description>
     <url>https://github.com/antoinemeyer/mock-in-bean</url>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
-        <version>2.2.0.RELEASE</version>
+        <version>2.6.15</version>
     </parent>
 
     <dependencies>

--- a/src/main/java/com/teketik/test/mockinbean/BeanFieldState.java
+++ b/src/main/java/com/teketik/test/mockinbean/BeanFieldState.java
@@ -1,22 +1,20 @@
 package com.teketik.test.mockinbean;
 
 import org.springframework.test.context.TestContext;
+import org.springframework.util.ReflectionUtils;
 
 import java.lang.reflect.Field;
 
 class BeanFieldState extends FieldState {
 
-    private Object bean;
+    final Object bean;
 
-    private Object originalValue;
+    final Object originalValue;
 
-    private Object mockableValue;
-
-    public BeanFieldState(Object bean, Field field, Object originalValue, Object mockableValue, Definition definition) {
+    public BeanFieldState(Object bean, Field field, Object originalValue, Definition definition) {
         super(field, definition);
         this.bean = bean;
         this.originalValue = originalValue;
-        this.mockableValue = mockableValue;
     }
 
     @Override
@@ -24,11 +22,13 @@ class BeanFieldState extends FieldState {
         return bean;
     }
 
-    public Object getMockableValue() {
-        return mockableValue;
+    public void rollback(TestContext testContext) {
+        final Object target = resolveTarget(testContext);
+        ReflectionUtils.setField(field, target, originalValue);
     }
 
-    public Object getOriginalValue() {
-        return originalValue;
+    public Object createMockOrSpy() {
+        return definition.create(originalValue);
     }
+
 }

--- a/src/main/java/com/teketik/test/mockinbean/BeanFieldState.java
+++ b/src/main/java/com/teketik/test/mockinbean/BeanFieldState.java
@@ -8,9 +8,15 @@ class BeanFieldState extends FieldState {
 
     private Object bean;
 
-    public BeanFieldState(Object bean, Field field, Object originalValue, Definition definition) {
-        super(field, originalValue, definition);
+    private Object originalValue;
+
+    private Object mockableValue;
+
+    public BeanFieldState(Object bean, Field field, Object originalValue, Object mockableValue, Definition definition) {
+        super(field, definition);
         this.bean = bean;
+        this.originalValue = originalValue;
+        this.mockableValue = mockableValue;
     }
 
     @Override
@@ -18,4 +24,11 @@ class BeanFieldState extends FieldState {
         return bean;
     }
 
+    public Object getMockableValue() {
+        return mockableValue;
+    }
+
+    public Object getOriginalValue() {
+        return originalValue;
+    }
 }

--- a/src/main/java/com/teketik/test/mockinbean/BeanUtils.java
+++ b/src/main/java/com/teketik/test/mockinbean/BeanUtils.java
@@ -1,5 +1,7 @@
 package com.teketik.test.mockinbean;
 
+import org.springframework.aop.TargetSource;
+import org.springframework.aop.framework.Advised;
 import org.springframework.aop.framework.AopProxyUtils;
 import org.springframework.aop.support.AopUtils;
 import org.springframework.context.ApplicationContext;
@@ -44,8 +46,8 @@ abstract class BeanUtils {
                 .findFirst()
                 .orElseThrow(() -> new IllegalArgumentException("No beans of type " + type + " and name " + name));
         }
-        return AopUtils.isAopProxy(beanOrProxy) 
-            ? (T) AopProxyUtils.getSingletonTarget(beanOrProxy) 
+        return AopUtils.isAopProxy(beanOrProxy)
+            ? (T) AopProxyUtils.getSingletonTarget(beanOrProxy)
             : beanOrProxy;
     }
 
@@ -92,6 +94,29 @@ abstract class BeanUtils {
                     )
             );
             return (Field) results[1];
+        }
+        return null;
+    }
+
+    static @Nullable TargetSource getProxyTarget(Object candidate) {
+        try {
+            while (AopUtils.isAopProxy(candidate) && candidate instanceof Advised) {
+                Advised advised = (Advised) candidate;
+                TargetSource targetSource = advised.getTargetSource();
+
+                if (targetSource.isStatic()) {
+                    Object target = targetSource.getTarget();
+
+                    if (target == null || !AopUtils.isAopProxy(target)) {
+                        return targetSource;
+                    }
+                    candidate = target;
+                } else {
+                    return null;
+                }
+            }
+        } catch (Throwable ex) {
+            throw new IllegalStateException("Failed to unwrap proxied object", ex);
         }
         return null;
     }

--- a/src/main/java/com/teketik/test/mockinbean/FieldState.java
+++ b/src/main/java/com/teketik/test/mockinbean/FieldState.java
@@ -1,6 +1,5 @@
 package com.teketik.test.mockinbean;
 
-import org.springframework.lang.Nullable;
 import org.springframework.test.context.TestContext;
 
 import java.lang.reflect.Field;
@@ -9,14 +8,10 @@ abstract class FieldState {
 
     final Field field;
 
-    @Nullable
-    final Object originalValue;
-
     final Definition definition;
 
-    public FieldState(Field targetField, Object originalValue, Definition definition) {
+    public FieldState(Field targetField, Definition definition) {
         this.field = targetField;
-        this.originalValue = originalValue;
         this.definition = definition;
     }
 

--- a/src/main/java/com/teketik/test/mockinbean/MockInBeanTestExecutionListener.java
+++ b/src/main/java/com/teketik/test/mockinbean/MockInBeanTestExecutionListener.java
@@ -127,8 +127,7 @@ class MockInBeanTestExecutionListener extends AbstractTestExecutionListener {
                 //if the target bean has been spied on, need to push into this spy as well (to allow mock in spies)
                 Optional.ofNullable(spyTracker.get(bean))
                     .ifPresent(spy ->inject(fieldState.field, spy, mockOrSpy));
-
-        });
+            });
 
         super.beforeTestMethod(testContext);
     }

--- a/src/main/java/com/teketik/test/mockinbean/MockInBeanTestExecutionListener.java
+++ b/src/main/java/com/teketik/test/mockinbean/MockInBeanTestExecutionListener.java
@@ -102,7 +102,7 @@ class MockInBeanTestExecutionListener extends AbstractTestExecutionListener {
         final Map<Definition, Object> mockOrSpys = new HashMap<>();
         final LinkedList<FieldState> fieldStates = (LinkedList<FieldState>) applicableTestContext.getAttribute(ORIGINAL_VALUES_ATTRIBUTE_NAME);
         final Map<Object, Object> spyTracker = new IdentityHashMap<>();
-        // First loop to setup all the mocks and spies
+        //First loop to setup all the mocks and spies
         fieldStates
             .stream()
             .filter(BeanFieldState.class::isInstance)
@@ -117,14 +117,14 @@ class MockInBeanTestExecutionListener extends AbstractTestExecutionListener {
                     }
                 }
             });
-        // Second loop to process the injections (handling mocks in spies)
+        //Second loop to process the injections (handling mocks in spies)
         fieldStates
             .forEach(fieldState -> {
                 final Object mockOrSpy = mockOrSpys.get(fieldState.definition);
                 final Object bean = fieldState.resolveTarget(applicableTestContext);
-                // inject in original bean
+                //inject in original bean
                 inject(fieldState.field, bean, mockOrSpy);
-                // if the target bean has been spied on, need to push into this spy as well (to allow mock in spies)
+                //if the target bean has been spied on, need to push into this spy as well (to allow mock in spies)
                 Optional.ofNullable(spyTracker.get(bean))
                     .ifPresent(spy ->inject(fieldState.field, spy, mockOrSpy));
 

--- a/src/main/java/com/teketik/test/mockinbean/MockInBeanTestExecutionListener.java
+++ b/src/main/java/com/teketik/test/mockinbean/MockInBeanTestExecutionListener.java
@@ -64,7 +64,7 @@ class MockInBeanTestExecutionListener extends AbstractTestExecutionListener {
                 beanField.setAccessible(true);
                 final Object beanFieldValue = ReflectionUtils.getField(beanField, inBean);
                 final TargetSource proxyTarget = BeanUtils.getProxyTarget(beanFieldValue);
-                BeanFieldState beanFieldState;
+                final BeanFieldState beanFieldState;
                 if (proxyTarget != null) {
                     beanFieldState = new ProxiedBeanFieldState(inBean, beanField, beanFieldValue, proxyTarget, definition);
                 } else {
@@ -116,6 +116,7 @@ class MockInBeanTestExecutionListener extends AbstractTestExecutionListener {
                 //if the target bean has been spied on, need to push into this spy as well (to allow mock in spies)
                 Optional.ofNullable(spyTracker.get(bean))
                     .ifPresent(spy ->inject(fieldState.field, spy, mockOrSpy));
+
             });
 
         super.beforeTestMethod(testContext);

--- a/src/main/java/com/teketik/test/mockinbean/ProxiedBeanFieldState.java
+++ b/src/main/java/com/teketik/test/mockinbean/ProxiedBeanFieldState.java
@@ -1,0 +1,42 @@
+package com.teketik.test.mockinbean;
+
+import org.springframework.aop.TargetSource;
+import org.springframework.test.context.TestContext;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.lang.reflect.Field;
+
+/**
+ * Special kind of {@link BeanFieldState} handling proxied beans (like aspects).<br>
+ * The mock is not injected into the <code>field</code> but into the <code>target</code> of its {@link TargetSource}.
+ * @author Antoine Meyer
+ */
+class ProxiedBeanFieldState extends BeanFieldState {
+
+    private static void setTargetSourceValue(TargetSource targetSource, Object value) {
+        ReflectionTestUtils.setField(targetSource, "target", value);
+    }
+
+    final TargetSource proxyTargetSource;
+
+    final Object proxyTargetOriginalValue;
+
+    public ProxiedBeanFieldState(Object inBean, Field beanField, Object beanFieldValue, TargetSource proxyTargetSource, Definition definition) throws Exception {
+        super(inBean, beanField, beanFieldValue, definition);
+        this.proxyTargetSource = proxyTargetSource;
+        this.proxyTargetOriginalValue = proxyTargetSource.getTarget();
+    }
+
+    @Override
+    public void rollback(TestContext testContext) {
+        setTargetSourceValue(proxyTargetSource, proxyTargetOriginalValue);
+    }
+
+    @Override
+    public Object createMockOrSpy() {
+        Object applicableMockOrSpy = definition.create(proxyTargetOriginalValue);
+        setTargetSourceValue(proxyTargetSource, applicableMockOrSpy);
+        return originalValue; //the 'mock or spy' to operate for proxied beans are the actual proxy
+    }
+
+}

--- a/src/main/java/com/teketik/test/mockinbean/ProxiedBeanFieldState.java
+++ b/src/main/java/com/teketik/test/mockinbean/ProxiedBeanFieldState.java
@@ -10,6 +10,7 @@ import java.lang.reflect.Field;
  * Special kind of {@link BeanFieldState} handling proxied beans (like aspects).<br>
  * The mock is not injected into the <code>field</code> but into the <code>target</code> of its {@link TargetSource}.
  * @author Antoine Meyer
+ * @see https://github.com/antoinemeyer/mock-in-bean/issues/23
  */
 class ProxiedBeanFieldState extends BeanFieldState {
 

--- a/src/main/java/com/teketik/test/mockinbean/TestFieldState.java
+++ b/src/main/java/com/teketik/test/mockinbean/TestFieldState.java
@@ -6,8 +6,8 @@ import java.lang.reflect.Field;
 
 class TestFieldState extends FieldState {
 
-    TestFieldState(Field targetField, Object originalValue, Definition definition) {
-        super(targetField, originalValue, definition);
+    TestFieldState(Field targetField, Definition definition) {
+        super(targetField, definition);
     }
 
     @Override

--- a/src/test/java/com/teketik/test/mockinbean/test/VerifyAdvisedSpyInBeanTest.java
+++ b/src/test/java/com/teketik/test/mockinbean/test/VerifyAdvisedSpyInBeanTest.java
@@ -1,0 +1,86 @@
+package com.teketik.test.mockinbean.test;
+
+import static org.mockito.Mockito.verify;
+
+import com.teketik.test.mockinbean.SpyInBean;
+import com.teketik.test.mockinbean.test.VerifyAdvisedSpyInBeanTest.Config.LoggingService;
+import com.teketik.test.mockinbean.test.VerifyAdvisedSpyInBeanTest.Config.ProviderService;
+
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.Ordered;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
+import org.springframework.test.context.TestContext;
+import org.springframework.test.context.TestExecutionListener;
+import org.springframework.test.context.TestExecutionListeners;
+import org.springframework.test.context.TestExecutionListeners.MergeMode;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * Covering test case from
+ * https://github.com/inkassso/mock-in-bean-issue-23/blob/master/src/test/java/com/github/inkassso/mockinbean/issue23/service/BrokenLoggingServiceTest1_SpyInBean.java
+ */
+@TestExecutionListeners(value = {VerifyAdvisedSpyInBeanTest.class}, mergeMode = MergeMode.MERGE_WITH_DEFAULTS)
+@SpringBootTest
+public class VerifyAdvisedSpyInBeanTest implements TestExecutionListener, Ordered {
+
+    @org.springframework.boot.test.context.TestConfiguration
+    static class Config {
+
+        @Aspect
+        @Component
+        public class AnAspect {
+            @Before("execution(* com.teketik.test.mockinbean.test.VerifyAdvisedSpyInBeanTest.Config.ProviderService.provideValue())")
+            public void logBeforeMethodExecution() {}
+        }
+
+        @Service
+        public class ProviderService {
+            public String provideValue() {
+                return "";
+            }
+        }
+
+        @Component
+        public class LoggingService {
+
+            @Autowired
+            private ProviderService providerService;
+
+            public void logCurrentValue() {
+                providerService.provideValue();
+            }
+        }
+    }
+
+    @Autowired
+    protected LoggingService loggingService;
+
+    @SpyInBean(LoggingService.class)
+    private ProviderService providerService;
+
+    @Test
+    void testLogCurrentValue() {
+        loggingService.logCurrentValue();
+        verify(providerService).provideValue();
+    }
+
+    @Override
+    public void afterTestClass(TestContext testContext) throws Exception {
+        final ApplicationContext applicationContext = testContext.getApplicationContext();
+        final Object loggingServiceBean = applicationContext.getBean(LoggingService.class);
+        Assertions.assertSame(applicationContext.getBean(ProviderService.class), ReflectionTestUtils.getField(loggingServiceBean, "providerService"));
+    }
+
+    @Override
+    public int getOrder() {
+        return Integer.MAX_VALUE;
+    }
+
+}


### PR DESCRIPTION
fixes https://github.com/antoinemeyer/mock-in-bean/issues/23

I am not entirely happy with that solution, but it does work (until it will not).
Tested on `2.6.15`, `2.7.18`, `3.0.13`, `3.1.12`, `3.2.11`, `3.3.5`.
